### PR TITLE
Add global stock utilities with yfinance

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from settings import *
 from main_func import *
+from global_stocks import get_price_series, save_series_to_csv
 
 #Cargo las variables de entorno
 
@@ -33,6 +34,10 @@ if __name__== '__main__':
             usd_ars= get_assets("currencies","usd-ars",0,path_currencies)
             usd_bz= get_assets("currencies","usd-brl",1,path_currencies)
           #  usd_10y= get_assets("rates-bonds","u.s.-10-year-bond-yield",0,path_macro)
+            global_symbols = ["AAPL", "MSFT"]
+            for sym in global_symbols:
+                series = get_price_series(sym, "2010-01-01", datetime.now().strftime("%Y-%m-%d"))
+                save_series_to_csv(series, path_stocks / f"{sym}.csv")
             print(start)
             print(datetime.now)
     else:

--- a/global_stocks.py
+++ b/global_stocks.py
@@ -1,0 +1,65 @@
+"""Utilities for downloading global stock data using yfinance.
+
+This module provides helper functions to obtain price series for
+international markets and save them to CSV files for later processing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+import pandas as pd
+import yfinance as yf
+
+
+def get_price_series(symbol: str, start: str, end: str) -> pd.DataFrame:
+    """Download OHLCV data for ``symbol`` between ``start`` and ``end``.
+
+    Parameters
+    ----------
+    symbol: str
+        Ticker symbol recognised by Yahoo Finance.
+    start: str
+        Start date in ``YYYY-MM-DD`` format.
+    end: str
+        End date in ``YYYY-MM-DD`` format.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame indexed by date with columns ``close``, ``var``, ``open``,
+        ``max``, ``min``, ``volume``, ``ticker``, ``country`` and ``asset``.
+    """
+    data = yf.download(symbol, start=start, end=end, progress=False)
+    if data.empty:
+        return pd.DataFrame(
+            columns=["close", "var", "open", "max", "min", "volume", "ticker", "country", "asset"]
+        )
+
+    data.rename(
+        columns={
+            "Open": "open",
+            "High": "max",
+            "Low": "min",
+            "Close": "close",
+            "Volume": "volume",
+        },
+        inplace=True,
+    )
+    data["var"] = data["close"].pct_change().fillna(0)
+    data["ticker"] = symbol
+    data["country"] = "global"
+    data["asset"] = "stocks"
+    data.index.name = "dateTime"
+    return data[["close", "var", "open", "max", "min", "volume", "ticker", "country", "asset"]]
+
+
+def save_series_to_csv(df: pd.DataFrame, path: Union[str, Path]) -> None:
+    """Save the provided price series ``df`` to ``path``.
+
+    The directory for ``path`` is created if it does not already exist.
+    """
+    out_path = Path(path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(out_path)

--- a/main_func.py
+++ b/main_func.py
@@ -10,6 +10,7 @@ import pandas as pd
 import numpy as np
 from datetime import *
 from binance.client import Client
+from global_stocks import get_price_series, save_series_to_csv
 
 
 ############################################################################################################################
@@ -392,21 +393,20 @@ def act_db_csv(path_crypto, path_stocks, path_indexes, path_commodities, path_cu
                     df2.to_csv(path_macro+name+".csv")
                     print(name+"ok")
             elif acciones == True:
+                df1=pd.read_csv(path_stocks+name+".csv")
+                df1=df1.set_index('dateTime')
                 try:
-                    df1=pd.read_csv(path_stocks+name+".csv")
                     curr=api_iol.get_hist_data_iol('bcBA', name, date, date.today(),'argentina', path_stocks, psw_iol=pass_iol, user_iol=user_iol)
-                    df1=df1.set_index('dateTime')
-                    df2=pd.concat([df1, curr], axis=0)
-                    print("saving")
-                    df2.to_csv(path_stocks+name+".csv")
-                    print(name+"ok")
-                except:
-                    df1=pd.read_csv(path_stocks+name+".csv")
-                    curr=api_iol.get_hist_data_iol('bcBA', name, date, date.today(),'estados_unidos', path_stocks, psw_iol=pass_iol, user_iol=user_iol)
-                    df1=df1.set_index('dateTime')
-                    df2=pd.concat([df1, curr], axis=0)
-                    print("saving")
-                    df2.to_csv(path_stocks+name+".csv")
-                    print(name+"ok")
+                except Exception:
+                    try:
+                        curr=api_iol.get_hist_data_iol('bcBA', name, date, date.today(),'estados_unidos', path_stocks, psw_iol=pass_iol, user_iol=user_iol)
+                    except Exception:
+                        curr=get_price_series(name, date, date.today())
+                mask = (curr.index > date)
+                curr=curr.loc[mask]
+                df2=pd.concat([df1, curr], axis=0)
+                print("saving")
+                save_series_to_csv(df2, path_stocks+name+".csv")
+                print(name+"ok")
     print(datetime.now())
             


### PR DESCRIPTION
## Summary
- add `global_stocks` module to download global stock price series via yfinance
- update `act_db_csv` to use new utilities when IOL data is unavailable
- extend `app.py` with examples for downloading global tickers

## Testing
- `python -m py_compile global_stocks.py main_func.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68aafcf0ccb88324bee5c875851e99cb