### PR TITLE
feat: manage API tokens with refresh capability

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,8 +15,8 @@ if __name__== '__main__':
 
     if create_DB== True:
             Binance_Api.get_db_crypto(path_crypto, "2018-01-01 00:00:00")# Genero la BD desde 2018 con timeframe de 5´
-            IOL_Api.get_DB_iol("acciones", "bcBA", "panel general", "argentina", "2010-01-01",path_stocks, USER_IOL, PASS_IOL)
-            IOL_Api.get_DB_iol("acciones", "nySE", "sp500", "estados_unidos", "2010-01-01",path_stocks, USER_IOL, PASS_IOL)
+            IOL_Api.get_DB_iol("acciones", "bcBA", "panel general", "argentina", "2010-01-01", path_stocks)
+            IOL_Api.get_DB_iol("acciones", "nySE", "sp500", "estados_unidos", "2010-01-01", path_stocks)
             Witi_oil= get_assets("commodities", "crude-oil",1,path_commodities)
             Soybeans= get_assets("commodities", "us-soybeans",1,path_commodities)
             Corn= get_assets("commodities", "us-corn",1,path_commodities)


### PR DESCRIPTION
## Summary
- add token refresh mechanism with timestamp tracking
- reuse existing IOL tokens across requests
- simplify IOL request helpers to use internal token management

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aafd15b33483248b15a59a6db7f307