### PR TITLE
feat: support bonds and options data

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,8 +15,10 @@ if __name__== '__main__':
 
     if create_DB== True:
             Binance_Api.get_db_crypto(path_crypto, "2018-01-01 00:00:00")# Genero la BD desde 2018 con timeframe de 5´
-            IOL_Api.get_DB_iol("acciones", "bcBA", "panel general", "argentina", "2010-01-01",path_stocks, USER_IOL, PASS_IOL)
-            IOL_Api.get_DB_iol("acciones", "nySE", "sp500", "estados_unidos", "2010-01-01",path_stocks, USER_IOL, PASS_IOL)
+            IOL_Api.get_DB_iol("acciones", "bcBA", "panel general", "argentina", "2010-01-01", path_stocks, USER_IOL, PASS_IOL)
+            IOL_Api.get_DB_iol("acciones", "nySE", "sp500", "estados_unidos", "2010-01-01", path_stocks, USER_IOL, PASS_IOL)
+            IOL_Api.get_DB_iol("bonos", "bcBA", "panel general", "argentina", "2010-01-01", path_bonds, USER_IOL, PASS_IOL)
+            IOL_Api.get_DB_iol("opciones", "bcBA", "opciones", "argentina", "2010-01-01", path_options, USER_IOL, PASS_IOL)
             Witi_oil= get_assets("commodities", "crude-oil",1,path_commodities)
             Soybeans= get_assets("commodities", "us-soybeans",1,path_commodities)
             Corn= get_assets("commodities", "us-corn",1,path_commodities)

--- a/settings.py
+++ b/settings.py
@@ -35,6 +35,8 @@ save_csv = True
 BASE_PATH = Path(__file__).resolve().parent
 dataset = BASE_PATH / "dataset"
 path_stocks = dataset / "acciones"
+path_bonds = dataset / "bonos"
+path_options = dataset / "opciones"
 path_crypto = dataset / "crypto"
 path_commodities = dataset / "commodities"
 path_indexes = dataset / "indices"
@@ -45,6 +47,8 @@ path_macro = dataset / "macro"
 # Crear los directorios en caso de que no existan
 for directory in (
     path_stocks,
+    path_bonds,
+    path_options,
     path_crypto,
     path_commodities,
     path_indexes,


### PR DESCRIPTION
## Summary
- add dedicated directories for bonds and options
- extend IOL client with bond and option historical fetch methods
- update app driver to build bond and option datasets

## Testing
- `python -m py_compile settings.py main_func.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68aafd18acd4832484dbc558c3db7fc3