### PR TITLE
Parallelize IOL downloads with configurable threads

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,8 +15,8 @@ if __name__== '__main__':
 
     if create_DB== True:
             Binance_Api.get_db_crypto(path_crypto, "2018-01-01 00:00:00")# Genero la BD desde 2018 con timeframe de 5´
-            IOL_Api.get_DB_iol("acciones", "bcBA", "panel general", "argentina", "2010-01-01",path_stocks, USER_IOL, PASS_IOL)
-            IOL_Api.get_DB_iol("acciones", "nySE", "sp500", "estados_unidos", "2010-01-01",path_stocks, USER_IOL, PASS_IOL)
+            IOL_Api.get_DB_iol("acciones", "bcBA", "panel general", "argentina", "2010-01-01", path_stocks, USER_IOL, PASS_IOL, threads=THREADS)
+            IOL_Api.get_DB_iol("acciones", "nySE", "sp500", "estados_unidos", "2010-01-01", path_stocks, USER_IOL, PASS_IOL, threads=THREADS)
             Witi_oil= get_assets("commodities", "crude-oil",1,path_commodities)
             Soybeans= get_assets("commodities", "us-soybeans",1,path_commodities)
             Corn= get_assets("commodities", "us-corn",1,path_commodities)

--- a/settings.py
+++ b/settings.py
@@ -24,6 +24,7 @@ PASS_IOL = os.getenv("PASS_IOL")
 URL_TOKEN = os.getenv("URL_TOKEN")
 GRANT_TYPE = os.getenv("GRANT_TYPE")
 URL_API = os.getenv("URL_API")
+THREADS = int(os.getenv("THREADS", "4"))
 
 
 # Elijo el formato a guardar (csv, sql o ambas)


### PR DESCRIPTION
## Summary
- fetch IOL symbols in parallel using `ThreadPoolExecutor`
- allow configurable thread count via `THREADS` setting and pass to the downloader

## Testing
- `python -m py_compile main_func.py app.py settings.py`

------
https://chatgpt.com/codex/tasks/task_e_68aafd201d3883248aab32ad5cbbb56e