### PR TITLE
Add CoinGecko support for crypto data

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,41 +1,58 @@
 from settings import *
 from main_func import *
+from coingecko_api import get_coin_list, get_historical_data
+import os
 
-#Cargo las variables de entorno
-
-
-
-
-if __name__== '__main__':
-    start= datetime.now()
-    create_DB= False
-    IOL_Api= iol(USER_IOL, PASS_IOL)
-    Binance_Api= binance()
+# Cargo las variables de entorno
 
 
-    if create_DB== True:
-            Binance_Api.get_db_crypto(path_crypto, "2018-01-01 00:00:00")# Genero la BD desde 2018 con timeframe de 5´
-            IOL_Api.get_DB_iol("acciones", "bcBA", "panel general", "argentina", "2010-01-01",path_stocks, USER_IOL, PASS_IOL)
-            IOL_Api.get_DB_iol("acciones", "nySE", "sp500", "estados_unidos", "2010-01-01",path_stocks, USER_IOL, PASS_IOL)
-            Witi_oil= get_assets("commodities", "crude-oil",1,path_commodities)
-            Soybeans= get_assets("commodities", "us-soybeans",1,path_commodities)
-            Corn= get_assets("commodities", "us-corn",1,path_commodities)
-            Wheat= get_assets("commodities","london-wheat",1,path_commodities)
-            Copper= get_assets("commodities","copper",1,path_commodities)
-            Samp= get_assets("indices","us-spx-500",1,path_indexes)
-            Dow_joes= get_assets("indices","us-30",1,path_indexes)
-            Nasdaq= get_assets("indices","nasdaq-composite",0,path_indexes)
-            Bovespa= get_assets("indices","bovespa",0,path_indexes)
-            Shangai= get_assets("indices","shanghai-composite",0,path_indexes)
-            Ibex= get_assets("indices","spain-35",1,path_indexes)
-            uk_100= get_assets("indices","uk-100",1,path_indexes)
-            merval= get_assets("indices","merv",0,path_indexes)
-            usd_ars= get_assets("currencies","usd-ars",0,path_currencies)
-            usd_bz= get_assets("currencies","usd-brl",1,path_currencies)
-          #  usd_10y= get_assets("rates-bonds","u.s.-10-year-bond-yield",0,path_macro)
-            print(start)
-            print(datetime.now)
+if __name__ == '__main__':
+    start = datetime.now()
+    create_DB = False
+    source = os.getenv("CRYPTO_SOURCE", "binance").lower()
+
+    IOL_Api = iol(USER_IOL, PASS_IOL)
+    binance_api = binance() if source in ("binance", "both") else None
+
+    if create_DB == True:
+        if source in ("binance", "both") and binance_api is not None:
+            binance_api.get_db_crypto(path_crypto, "2018-01-01 00:00:00")  # Genero la BD desde 2018 con timeframe de 5´
+        if source in ("coingecko", "both"):
+            coins = get_coin_list()
+            for coin in coins["id"][:10]:
+                try:
+                    hist = get_historical_data(coin, "2018-01-01 00:00:00")
+                    hist.to_csv(path_crypto / f"{coin}.csv")
+                except Exception as exc:
+                    print(f"{coin}: {exc}")
+        IOL_Api.get_DB_iol("acciones", "bcBA", "panel general", "argentina", "2010-01-01", path_stocks, USER_IOL, PASS_IOL)
+        IOL_Api.get_DB_iol("acciones", "nySE", "sp500", "estados_unidos", "2010-01-01", path_stocks, USER_IOL, PASS_IOL)
+        Witi_oil = get_assets("commodities", "crude-oil", 1, path_commodities)
+        Soybeans = get_assets("commodities", "us-soybeans", 1, path_commodities)
+        Corn = get_assets("commodities", "us-corn", 1, path_commodities)
+        Wheat = get_assets("commodities", "london-wheat", 1, path_commodities)
+        Copper = get_assets("commodities", "copper", 1, path_commodities)
+        Samp = get_assets("indices", "us-spx-500", 1, path_indexes)
+        Dow_joes = get_assets("indices", "us-30", 1, path_indexes)
+        Nasdaq = get_assets("indices", "nasdaq-composite", 0, path_indexes)
+        Bovespa = get_assets("indices", "bovespa", 0, path_indexes)
+        Shangai = get_assets("indices", "shanghai-composite", 0, path_indexes)
+        Ibex = get_assets("indices", "spain-35", 1, path_indexes)
+        uk_100 = get_assets("indices", "uk-100", 1, path_indexes)
+        merval = get_assets("indices", "merv", 0, path_indexes)
+        usd_ars = get_assets("currencies", "usd-ars", 0, path_currencies)
+        usd_bz = get_assets("currencies", "usd-brl", 1, path_currencies)
+        # usd_10y= get_assets("rates-bonds","u.s.-10-year-bond-yield",0,path_macro)
+        print(start)
+        print(datetime.now)
     else:
-      act_db_csv(path_crypto,path_stocks, path_indexes, path_commodities, path_currencies, path_macro, pass_iol= PASS_IOL,user_iol= USER_IOL)
-
-
+        act_db_csv(
+            path_crypto,
+            path_stocks,
+            path_indexes,
+            path_commodities,
+            path_currencies,
+            path_macro,
+            pass_iol=PASS_IOL,
+            user_iol=USER_IOL,
+        )

--- a/coingecko_api.py
+++ b/coingecko_api.py
@@ -1,0 +1,82 @@
+import requests
+import pandas as pd
+from datetime import datetime
+
+BASE_URL = "https://api.coingecko.com/api/v3"
+
+
+def get_coin_list():
+    """Return a DataFrame with the list of supported coins."""
+    url = f"{BASE_URL}/coins/list"
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+    return pd.DataFrame(data)
+
+
+def get_historical_data(symbol: str, since: str) -> pd.DataFrame:
+    """Return historical market data for a given ``symbol``.
+
+    Parameters
+    ----------
+    symbol:
+        Coin identifier as used by CoinGecko (e.g. ``bitcoin``).
+    since:
+        Start date in ISO format (``YYYY-MM-DD`` or with time). The
+        returned DataFrame will be filtered so that the index is greater
+        or equal to this date.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Data formatted similarly to the CSV files produced for Binance.
+    """
+    # Retrieve the complete market chart and filter afterwards to avoid
+    # multiple API calls for different ranges.
+    url = f"{BASE_URL}/coins/{symbol}/market_chart"
+    params = {"vs_currency": "usd", "days": "max"}
+    response = requests.get(url, params=params, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+
+    prices = pd.DataFrame(data.get("prices", []), columns=["dateTime", "close"])
+    prices["dateTime"] = pd.to_datetime(prices["dateTime"], unit="ms")
+
+    volumes = pd.DataFrame(data.get("total_volumes", []), columns=["dateTime", "volume"])
+    volumes["dateTime"] = pd.to_datetime(volumes["dateTime"], unit="ms")
+
+    df = pd.merge(prices, volumes, on="dateTime", how="left")
+
+    # Replicate Binance CSV structure
+    df["open"] = df["close"]
+    df["max"] = df["close"]
+    df["min"] = df["close"]
+    df["closeTime"] = pd.NaT
+    df["quoteAssetVolume"] = pd.NA
+    df["numberOfTrades"] = pd.NA
+    df["takerBuyBaseVol"] = pd.NA
+    df["takerBuyQuoteVol"] = pd.NA
+    df["ignore"] = pd.NA
+    df["token"] = symbol.upper()
+    df["asset"] = "cryptocurrency"
+
+    df.set_index("dateTime", inplace=True)
+    if since:
+        since_dt = pd.to_datetime(since)
+        df = df.loc[df.index >= since_dt]
+
+    return df[[
+        "open",
+        "max",
+        "min",
+        "close",
+        "volume",
+        "closeTime",
+        "quoteAssetVolume",
+        "numberOfTrades",
+        "takerBuyBaseVol",
+        "takerBuyQuoteVol",
+        "ignore",
+        "token",
+        "asset",
+    ]]


### PR DESCRIPTION
## Summary
- add `coingecko_api` module to fetch crypto data from CoinGecko's market_chart
- allow choosing Binance, CoinGecko or both as crypto providers in app

## Testing
- `python -m py_compile coingecko_api.py app.py`
- `python -m py_compile main_func.py settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68aafd219134832483a753d54379281d