### PR TITLE
Add Finnhub stock data downloader

### DIFF
--- a/data_providers.py
+++ b/data_providers.py
@@ -16,6 +16,7 @@ from pandas_datareader import data as pdr
 import yfinance as yf
 from alpha_vantage.timeseries import TimeSeries
 from alpha_vantage.foreignexchange import ForeignExchange
+import finnhub
 
 from settings import (
     path_macro,
@@ -141,9 +142,43 @@ def fetch_alpha_vantage_stock(
     return df
 
 
+def fetch_finnhub_stock(
+    symbol: str,
+    start: str,
+    end: str,
+    api_key: str,
+) -> pd.DataFrame:
+    """Download daily OHLC data from Finnhub for *symbol*.
+
+    The resulting dataframe contains the columns ``open``, ``high``, ``low``,
+    ``close`` and ``volume``.
+    """
+    client = finnhub.Client(api_key=api_key)
+    start_ts = int(pd.Timestamp(start).timestamp())
+    end_ts = int(pd.Timestamp(end).timestamp())
+    data = client.stock_candles(symbol, "D", start_ts, end_ts)
+    if data.get("s") != "ok":
+        raise ValueError(f"Finnhub returned status {data.get('s')}")
+    df = pd.DataFrame(
+        {
+            "open": data["o"],
+            "high": data["h"],
+            "low": data["l"],
+            "close": data["c"],
+            "volume": data["v"],
+        },
+        index=pd.to_datetime(data["t"], unit="s"),
+    )
+    df.index.name = "date"
+    file_path = _ensure_path(path_stocks) / f"{symbol}.csv"
+    df.to_csv(file_path)
+    return df
+
+
 __all__ = [
     "fetch_fred",
     "fetch_yahoo",
     "fetch_alpha_vantage_fx",
     "fetch_alpha_vantage_stock",
+    "fetch_finnhub_stock",
 ]


### PR DESCRIPTION
## Summary
- add Finnhub client import and stock fetcher
- expose Finnhub fetcher in public API

## Testing
- `python -m py_compile data_providers.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab03c453cc8324bccef6ae0ddb78aa